### PR TITLE
Allow blocked IPs to be configured from Envoy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ crate-type = ["cdylib"]
 [dependencies]
 log = "0.4.17"
 proxy-wasm = "0.2.0"
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.91"

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -13,6 +13,17 @@ static_resources:
                 config:
                   name: "hermit"
                   root_id: "hermit"
+                  configuration:
+                    "@type": type.googleapis.com/google.protobuf.StringValue
+                    value: |
+                      { 
+                        "blocked_ips": 
+                          [
+                            "172.19.0.1", 
+                            "172.20.0.1", 
+                            "172.18.0.1"
+                          ] 
+                      }
                   vm_config:
                     runtime: envoy.wasm.runtime.v8
                     code:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
-#![feature(addr_parse_ascii)]
 use std::str;
 use std::time::Duration;
 
 use log::info;
+use proxy_wasm::hostcalls;
 use proxy_wasm::traits::*;
 use proxy_wasm::types::*;
+use serde::{Deserialize, Serialize};
 
+#[derive(Serialize, Deserialize, Debug)]
 struct Hermit {
     blocked_ips: Vec<String>,
 }
@@ -13,15 +15,27 @@ struct Hermit {
 impl Hermit {
     fn new() -> Self {
         return Self {
-            // Test blocking docker network IP
-            blocked_ips: vec!["172.19.0.1".to_string()],
+            blocked_ips: Vec::new(),
         };
+    }
+
+    fn get_source_address(&self) -> String {
+        // Retrieve source address from properties
+        let bytes: Vec<u8> = self.get_property(vec!["source", "address"]).unwrap();
+        match str::from_utf8(&bytes) {
+            Ok(a) => a,
+            Err(_) => "",
+        }
+        .split(":")
+        .take(1)
+        .map(|x| x.to_owned())
+        .collect()
     }
 }
 
 #[no_mangle]
 pub fn _start() {
-    proxy_wasm::set_log_level(LogLevel::Info);
+    proxy_wasm::set_log_level(LogLevel::Trace);
     proxy_wasm::set_stream_context(|_, _| -> Box<dyn StreamContext> { Box::new(Hermit::new()) });
 }
 
@@ -29,11 +43,14 @@ impl Context for Hermit {}
 
 impl RootContext for Hermit {
     fn on_vm_start(&mut self, _vm_configuration_size: usize) -> bool {
-        info!(
-            "Hermit VM instantiated. Blocking IPs: {}",
-            self.blocked_ips.join(", "),
-        );
+        hostcalls::log(LogLevel::Debug, "Hermit VM instantiated");
         self.set_tick_period(Duration::from_secs(2));
+        true
+    }
+
+    fn on_configure(&mut self, _plugin_configuration_size: usize) -> bool {
+        let data: Vec<u8> = self.get_plugin_configuration().unwrap();
+        self.blocked_ips = serde_json::from_slice::<Hermit>(&data).unwrap().blocked_ips;
         true
     }
 }
@@ -41,16 +58,10 @@ impl RootContext for Hermit {
 impl StreamContext for Hermit {
     fn on_new_connection(&mut self) -> Action {
         // Retrieve source address from properties
-        let bytes: Vec<u8> = self.get_property(vec!["source", "address"]).unwrap();
-        let addr: String = match str::from_utf8(&bytes) {
-            Ok(a) => a,
-            Err(_) => "",
-        }
-        .split(":")
-        .take(1)
-        .map(|x| x.to_owned())
-        .collect();
+        let addr = self.get_source_address();
+
         info!("Recieved connection from: {}", addr);
+        info!("Blocked IPs: {}", self.blocked_ips.join(", "));
 
         // Check if IP is in the block list
         if self.blocked_ips.contains(&addr) {


### PR DESCRIPTION
* Uses `on_configure` to pull in String value from envoy WASM plugin configuration to set blocked IPs
* Defines `create_stream_context` for the `RootContext` in order to properly link the child `StreamContext` and pass configuration. 

```
# Blocked docker network IP
Zeus git/hermit ‹jan0ski/configure-ips› » curl http://0.0.0.0:18000                           
curl: (52) Empty reply from server

# Allowed localhost IP
Zeus git/hermit ‹jan0ski/configure-ips› » docker exec -it hermit-proxy-1 curl http://localhost                              52 ↵
"Wasm filter test"
```